### PR TITLE
Added missing response field 'reading_time' (Reading time in minutes)…

### DIFF
--- a/GhostSharp/Entities/Post.cs
+++ b/GhostSharp/Entities/Post.cs
@@ -141,6 +141,13 @@ namespace GhostSharp.Entities
         public string CodeInjectionFoot { get; set; }
 
         /// <summary>
+        /// Reading time in minutes
+        /// </summary>
+        [JsonProperty("reading_time")]
+        [UpdatableField]
+        public int? ReadingTime { get; set; }
+
+        /// <summary>
         /// Facebook Card Image
         /// </summary>
         [JsonProperty("og_image")]

--- a/GhostSharp/Enums/PostFields.cs
+++ b/GhostSharp/Enums/PostFields.cs
@@ -175,6 +175,12 @@ namespace GhostSharp.Enums
         /// Excerpt
         /// </summary>
         [JsonProperty("excerpt")]
-        Excerpt = 134217728
-    }
+        Excerpt = 134217728,
+
+        /// <summary>
+        /// Reading Time in minutes
+        /// </summary>
+        [JsonProperty("reading_time")]
+        ReadingTime = 268435456
+   }
 }


### PR DESCRIPTION
Hi Grant,

Noticed that the 'reading_time' field was missing in the responses that I was getting using the client.  I'm not sure if this is a new field that got added in the current version the Ghost API?

With the following changes of adding ReadingTime to the Post entity and PostFields enum I was able to get the data populated testing against my own Ghost instance (you need to include ReadingTime as an PostQueryParams.Fields include I found).

Hope this helps,